### PR TITLE
Add description to HTML writer

### DIFF
--- a/utils/htmlWriter.js
+++ b/utils/htmlWriter.js
@@ -77,11 +77,13 @@ function writeEndpointHtml (endpoint) {
       'class="panel-heading" role="tab" id="heading' + cssEndpoint + '"'
     ) +
     htmlHelpers.wrapInDivWithProps(
-      htmlHelpers.wrapInDiv(
-        htmlHelpers.wrapInSubtitle('Description') +
-        htmlHelpers.wrapInSubtitleTitle(endpoint.description),
-        'container'
-      ) +
+      (endpoint.description
+        ? htmlHelpers.wrapInDiv(
+          htmlHelpers.wrapInSubtitle('Description') +
+          htmlHelpers.wrapInSubtitleTitle(endpoint.description),
+          'panel-body'
+        )
+        : '') +
       htmlHelpers.wrapInDiv(
         htmlHelpers.wrapInSubtitle('Request Data') +
         htmlHelpers.wrapInDiv(

--- a/utils/htmlWriter.js
+++ b/utils/htmlWriter.js
@@ -78,6 +78,11 @@ function writeEndpointHtml (endpoint) {
     ) +
     htmlHelpers.wrapInDivWithProps(
       htmlHelpers.wrapInDiv(
+        htmlHelpers.wrapInSubtitle('Description') +
+        htmlHelpers.wrapInSubtitleTitle(endpoint.description),
+        'container'
+      ) +
+      htmlHelpers.wrapInDiv(
         htmlHelpers.wrapInSubtitle('Request Data') +
         htmlHelpers.wrapInDiv(
           htmlHelpers.subtitlePreWrapper('Headers', endpoint.requestHeaders) +


### PR DESCRIPTION
Hi! Thanks for this library, can't believe it's not more popular, it generates documentation with minimal effort, couldn't find anything else like this.

Anyways, I was generating HTML docs and found that the `description` property was being ignored, so I just added it to the `htmlWriter`. It was previously only included on the Markdown writer.